### PR TITLE
Update 5+serve-with-petite.md

### DIFF
--- a/doc/example/5+serve-with-petite.md
+++ b/doc/example/5+serve-with-petite.md
@@ -279,7 +279,7 @@ scope with, e.g. prototype scope:
     	void initPetite() {
     		petite = new PetiteContainer();
     		if (isWebApplication == false) {
-    			petite.getManager()
+    			petite
                     .registerScope(SessionScope.class, new ProtoScope());
     		}
     		...


### PR DESCRIPTION
Removed getManager() call as there is no such method in PetiteContainer (at least in current version, 3.5.1)
