### PR TITLE
Update history.md

### DIFF
--- a/content/history.md
+++ b/content/history.md
@@ -2,7 +2,7 @@
 
 Recent history, release notes and previous releases.
 
-\<%= @items['/partials/release.md'].compiled\_content %\>
+<%= @items['/partials/release.md'].compiled_content %>
 
 ## [2016-03-24] Release v3.7.x
 


### PR DESCRIPTION
http://jodd.org/history.html does not seem to include the latest changes. It appears that is because the @items directive is not properly executed due to improperly placed escape characters.