### PR TITLE
Fixed grammatical errors and removed Google+ link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Jodd.org Website
 
-This is source for [Jodd](http://jodd.org) web site built with [nanoc](http://nanoc.ws).
+This is the source for [Jodd](https://jodd.org)'s web site built with [nanoc](https://nanoc.ws).
 
 All submissions are welcome. To submit a change, fork this repo,
 commit your changes, and send us a
-[pull request](http://help.github.com/send-pull-requests/).
+[pull request](https://help.github.com/send-pull-requests/).
 
 ## Build the site
 
@@ -16,20 +16,20 @@ to build it using Docker, so you don't have to install anything.
 
 Ruby 2.x is required to build the site.
 
-Get the `nanoc` gem, plus [kramdown](http://kramdown.gettalong.org/)
-for [Markdown](http://daringfireball.net/projects/markdown/) parsing:
+Get the `nanoc` gem, plus [kramdown](https://kramdown.gettalong.org/)
+for [Markdown](https://daringfireball.net/projects/markdown/) parsing:
 
 ```sh
 $ bundle install
 ```
 
-You can see the available commands with nanoc:
+You can see available commands with nanoc:
 
 ```sh
 $ bundle exec nanoc -h
 ```
 
-Nanoc has [some nice documentation](http://nanoc.ws/docs/tutorial/) to get you
+Nanoc has [some nice documentation](https://nanoc.ws/docs/tutorial/) to get you
 started. Though if you're mainly concerned with editing or adding content, you
 won't need to know much about nanoc.
 

--- a/content/404.md
+++ b/content/404.md
@@ -11,7 +11,7 @@ Sorry for your inconvenience.
 <div id="redirect" style="display: none; font-weight: bold; font-size: 1.1em; margin: 50px; color: green">
 
 	OLD LINK DETECTED!
-	Redirecting to new link in couple of seconds:
+	Redirecting to the new link in a couple of seconds:
 
 	<div id="newlink" style="margin: 20px 0; font-size: 2em;"></div>
 

--- a/content/beanutil/1+index.md
+++ b/content/beanutil/1+index.md
@@ -1,6 +1,6 @@
 # BeanUtil
 
-`BeanUtil` is bean manipulation library, that in a nutshell, allows
+`BeanUtil` is a bean manipulation library that, in a nutshell, allows
 setting and reading bean properties. Several features make `BeanUtil`
 distinct:
 

--- a/content/index.md
+++ b/content/index.md
@@ -2,7 +2,7 @@
 layout: '/jodd.html'
 ---
 
-**Jodd** is set of micro-frameworks and developer-friendly tools and utilities.
+**Jodd** is a set of micro-frameworks and developer-friendly tools and utilities.
 
 Simple code. Small size. Good performances. Whatever.
 

--- a/content/love.md
+++ b/content/love.md
@@ -3,7 +3,7 @@ toc: false
 ---
 # Who loves Jodd? ![heart](gfx/heart.png)
 
-**Awesome** people loves *Jodd* :) Share your success stories with the community!
+**Awesome** people love *Jodd* :) Share your success stories with the community!
 
 ## About...
 
@@ -26,18 +26,18 @@ or fail due to a side effect or misunderstanding of the underlying libraries.
 
 This is just a set of applications that use *Jodd* in same way.
 
-+ [Liferay Portal](http://liferay.com) - The best Java open-source enterprise portal, Liferay Portal, uses few *Jodd* tools and utilities in it's core: *BeanUtil*, *Paramo*, *Json* etc.
++ [Liferay Portal](https://liferay.com/) - The best Java open-source enterprise portal, Liferay Portal, uses a few *Jodd* tools and utilities in its core: *BeanUtil*, *Paramo*, *Json* etc.
 
-+ [Apache JMeter](http://jmeter.apache.org/) - Starting from version 2.9, this popular tool uses *Jerry* as one of the
++ [Apache JMeter](https://jmeter.apache.org/) - Starting from version 2.9, this popular tool uses *Jerry* as one of the
 extractors implementation.
 
-+ [BookWatchr](http://www.bookwatchr.com/) - The complete website made with Jodd and nothing else by Jodd :)
++ [BookWatchr](http://www.bookwatchr.com/) - A complete website made with Jodd and nothing else but Jodd :)
 
-+ [Chasse aux Livres](https://www.chasse-aux-livres.fr/) - The complete awesome website made in Jodd.
++ [Chasse aux Livres](https://www.chasse-aux-livres.fr/) - A complete awesome website made in Jodd.
 
-+ [Webit Script](http://zqq90.github.io/webit-script/) - Template-like script and engine, with grammar similar to JavaScript and JSP; and with great performances.
++ [Webit Script](https://zqq90.github.io/webit-script/) - Template-like script and engine, with grammar similar to JavaScript and JSP; and with great performances.
 
-+ **eComm** - Set of government intranet applications for electronic communication with citizens via email, SMS or phone; working in few European countries. Uses full *Jodd* stack.
++ **eComm** - Set of government intranet applications for electronic communication with citizens via email, SMS or phone; working in a few European countries. Uses full *Jodd* stack.
 
 + [Ihre Apotheke](http://www.ihre-apotheke.in) - Efficient pharmacy finder for Germany. Application uses *Madvoc*, *Joy*, the
 tag library, *Props* and finally the GZIP filter. Also, *Lagarto* was used for some back-end to fetch DBpedia data.

--- a/layouts/_footer.html
+++ b/layouts/_footer.html
@@ -13,7 +13,6 @@
 		<div id="overview">
 			<div class="inner">
 				<div id="share">
-					<a href="https://plus.google.com/share?url=http%3A%2F%jodd.org"><i class="fa fa-google-plus-square" aria-hidden="true"></i></a>
 					<a href="https://www.linkedin.com/shareArticle?mini=true&url=http%3A%2F%2Fjodd.org&title=Jodd%20-%20microframeworks&source=http%3A%2F%2Fjodd.org
 	"><i class="fa fa-linkedin-square" aria-hidden="true"></i></a>
 					<a href="https://twitter.com/intent/tweet?source=webclient&text=Check%20out%20Jodd%2C%20Java%20microframeworks%20and%20utilities%20%28http%3A%2F%2Fjodd.org%29"><i class="fa fa-twitter-square" aria-hidden="true"></i></a>

--- a/layouts/_overview.html
+++ b/layouts/_overview.html
@@ -27,7 +27,7 @@
 <img src="/gfx/swiss-knife.png" align="left" alt="Utilities"/>
 <h3><a href="/util/">Utilities</a></h3>
 <p>Jodd is packed with many carefully selected utilities;
-obsessively optimized for performances and to be easy to use.</p>
+obsessively optimized for performance and ease of use.</p>
 </div>
 
 <div class="obox">
@@ -82,7 +82,7 @@ file download, smart forms....</p>
 <div class="obox">
 <img src="/db/db.png" align="left" alt="DbOom"/>
 <h3><a href="/db/">Db &amp; DbOom</a></h3>
-<p>Efficient and thin layers that simplifies writing of database code significantly.</p>
+<p>Efficient and thin layers that simplify writing of database code significantly.</p>
 </div>
 
 <br clear="all"/>
@@ -96,7 +96,7 @@ file download, smart forms....</p>
 <div class="obox">
 <img src="/jtx/jtx.png" align="left" alt="JTX"/>
 <h3><a href="/jtx/">JTX</a></h3>
-<p>Manage transactions with this small stand-alone tx manager.</p>
+<p>Manage transactions with this small standalone tx manager.</p>
 </div>
 
 <br clear="all"/>
@@ -110,7 +110,7 @@ file download, smart forms....</p>
 <div class="obox">
 <img src="/lagarto/lagarto.png" align="left" alt="Lagarto"/>
 <h3><a href="/lagarto/">Lagarto</a></h3>
-<p>Fast and versatile all purpose HTML parser.</p>
+<p>Fast and versatile all-purpose HTML parser.</p>
 </div>
 
 <br clear="all"/>
@@ -132,7 +132,7 @@ file download, smart forms....</p>
 <div class="obox">
 <img src="/htmlstapler/stapler.png" align="left" alt="HtmlStapler"/>
 <h3><a href="/htmlstapler/">HtmlStapler</a></h3>
-<p>Transparently staple many javascript and css resources into single requests.</p>
+<p>Transparently staple many JavaScript and CSS resources into single requests.</p>
 </div>
 
 <div class="obox">
@@ -151,7 +151,7 @@ file download, smart forms....</p>
 <div class="obox" style="width:100%">
 <img src="/gfx/joy.png" align="left" alt="Jodd Joy"/>
 <h3><a href="/util/joy/index.html">Jodd Joy</a></h3>
-<p>Start coding your web applications right away, using best Jodd practices integrated into thin application layer.</p>
+<p>Start coding your web applications right away, using best Jodd practices integrated into a thin application layer.</p>
 </div>
 
 <br clear="all"/>

--- a/layouts/jodd.html
+++ b/layouts/jodd.html
@@ -206,7 +206,7 @@ $(document).ready(function() {
 <h2>The Importance of Being Small</h2>
 
 <p>
-<b>Jodd</b> is oriented around simpler libraries for doing what people have often times used heavyweight frameworks for: not in terms of performance though necessarily, but in terms of mental efforts and scaffolding required to get an MVP out the door. The very point of minimalism from a reliability perspective is to reduce points of failure in code with simply fewer parts.
+<b>Jodd</b> is oriented around simpler libraries for doing what people have oftentimes used heavyweight frameworks for: not in terms of performance though necessarily, but in terms of mental efforts and scaffolding required to get an MVP out the door. The very point of minimalism from a reliability perspective is to reduce points of failure in code with simply fewer parts.
 </p>
 		</div>
 	</section>

--- a/static/about/index.html
+++ b/static/about/index.html
@@ -35,7 +35,7 @@
 	<div id="q1" class="question">
 		<h2><span class="title"></span><span class="cursor"></span></h2>
 		<p>
-			Jodd is lightweight bundle of open-source Java micro-frameworks and tools for
+			Jodd is a lightweight bundle of open-source Java micro-frameworks and tools for
 			building super web applications. Packed in only 1.7 Mb.
 			Super easy to use.
 		</p>
@@ -57,7 +57,7 @@
 		</p>
 		<p>
 			Jodd focuses on 'Getting Things Done'.
-			We believe that Jodd frameworks suits most web applications.
+			We believe that Jodd frameworks suit most web applications.
 			Development should be a joyful process; your team
 			should be designing your own solutions and not learning
 			how to configure some monster :)


### PR DESCRIPTION
## Changes
- Links to sites with available HTTPS have been switched to use `https://`.
- Fixed a number of grammatical errors in various general-purpose documents (haven't changed the actual documentation).
- Removed the Google+ link from the footer as Google+ is [unavailable for personal use](https://support.google.com/plus/answer/9217723#whatshappening) since April.

## Notes
- The link to BookWatchr doesn't work, either because the site's down or dead.
- [Ihre Apotheke](http://www.ihre-apotheke.in) link is redirecting to [Apotheke Information](http://www.apotheke-information.de/). The link hasn't been changed as it's unclear whether the new site is still using Jodd.
- The site was built successfully on my local machine, and judging by [previous](https://app.netlify.com/sites/jodd/deploys/5ccae62c09bf240007216005) [failures](https://app.netlify.com/sites/jodd/deploys) upon external pull requests there seems to be an issue with the deploy job(?)
    - Or maybe it's just a [Netlify hiccup](https://github.com/freeCodeCamp/guide/issues/8355#issuecomment-411571940).