### PR TITLE
Fix typo in word 'dependencies' on in home content

### DIFF
--- a/src/layouts/home.njk
+++ b/src/layouts/home.njk
@@ -87,7 +87,7 @@
 				<a href="https://util.jodd.org" class="badge radial-out" target="_blank">
 					<div class="topic-head topic-icon bg-col-3">Util</div>
 					<div class="desc topic-title">
-						Various utilities, 0 zependencies. Fast bean library, type conversions and introspection.
+						Various utilities, 0 dependencies. Fast bean library, type conversions and introspection.
 					</div>
 				</a>
 


### PR DESCRIPTION
This changes 'zependencies' to 'dependencies', although I like the word 'zependencies' for zero dependencies ;)